### PR TITLE
Changed the enum34 dependency to enum-compat 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 comtypes==1.1.3.post2
-enum34;python_version<"3.6"
+enum34;python_version<"3.4"
 psutil==5.4.8
 future==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 comtypes==1.1.3.post2
-enum-compat==0.0.2
+enum34;python_version<"3.6"
 psutil==5.4.8
 future==0.15.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 comtypes==1.1.3.post2
-enum34==1.1.4
+enum-compat==0.0.2
 psutil==5.4.8
 future==0.15.2

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,12 @@
 
 from distutils.core import setup
 
+install_requires = [
+    'comtypes', 'enum34;python_version<"3.4"', 'psutil', 'future']
 setup(name='pycaw',
       version='20181226',
       description='Python Core Audio Windows Library',
       author='Andre Miras',
       url='https://github.com/AndreMiras/pycaw',
       packages=['pycaw'],
-      install_requires=['comtypes', 'enum34;python_version<"3.6"', 'psutil', 'future'])
+      install_requires=install_requires)

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 from distutils.core import setup
 
 setup(name='pycaw',
-      version='20190725',
+      version='20181226',
       description='Python Core Audio Windows Library',
       author='Andre Miras',
       url='https://github.com/AndreMiras/pycaw',
       packages=['pycaw'],
-      install_requires=['comtypes', 'enum-compat', 'psutil', 'future'])
+      install_requires=['comtypes', 'enum34;python_version<"3.6"', 'psutil', 'future'])

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,9 @@
 from distutils.core import setup
 
 setup(name='pycaw',
-      version='20181226',
+      version='20190725',
       description='Python Core Audio Windows Library',
       author='Andre Miras',
       url='https://github.com/AndreMiras/pycaw',
       packages=['pycaw'],
-      install_requires=['comtypes', 'enum34', 'psutil', 'future'])
+      install_requires=['comtypes', 'enum-compat', 'psutil', 'future'])


### PR DESCRIPTION
Enum34 is causing issues when building an executable with PyInstaller on Python 3.6. The issue is enum34 is not supported on Python >= 3.6. So enum-compat only installs enum34 if it's needed.