### PR TITLE
Fix COMError when calling GetAllDevices (#15)

### DIFF
--- a/pycaw/pycaw.py
+++ b/pycaw/pycaw.py
@@ -709,8 +709,13 @@ class AudioUtilities(object):
             propCount = store.GetCount()
             for j in range(propCount):
                 pk = store.GetAt(j)
-                value = store.GetValue(pk)
-                v = value.GetValue()
+                try:
+                    value = store.GetValue(pk)
+                    v = value.GetValue()
+                except:
+                    # Failure to get a property shouldn't be fatal.
+                    # https://github.com/AndreMiras/pycaw/issues/15
+                    continue
                 # TODO
                 # PropVariantClear(byref(value))
                 name = str(pk)


### PR DESCRIPTION
Updating Windows can update a driver, a shadow device entry for an older driver version, which does not return properties.

This will skip those properties.

Fixes #15. Fixes #3.