### PR TITLE
pycaw #15: Ignore properties that cause a COMError

### DIFF
--- a/pycaw/pycaw.py
+++ b/pycaw/pycaw.py
@@ -1,11 +1,13 @@
 ﻿"""
 Python wrapper around the Core Audio Windows API.
 """
+from _ctypes import COMError
 from ctypes import (HRESULT, POINTER, Structure, Union, c_float, c_longlong,
                     c_uint32)
 from ctypes.wintypes import (BOOL, DWORD, INT, LONG, LPCWSTR, LPWSTR, UINT,
                              ULARGE_INTEGER, VARIANT_BOOL, WORD)
 from enum import Enum
+import warnings
 
 import comtypes
 import psutil
@@ -708,9 +710,17 @@ class AudioUtilities(object):
         if store is not None:
             propCount = store.GetCount()
             for j in range(propCount):
-                pk = store.GetAt(j)
-                value = store.GetValue(pk)
-                v = value.GetValue()
+                try:
+                    pk = store.GetAt(j)
+                    value = store.GetValue(pk)
+                    v = value.GetValue()
+                except COMError as exc:
+                    warnings.warn(
+                        "COMError attempting to get property %r from device %r: %r" % (
+                            j, dev, exc
+                        )
+                    )
+                    continue
                 # TODO
                 # PropVariantClear(byref(value))
                 name = str(pk)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,9 +28,7 @@ def captured_output():
 class TestCore(unittest.TestCase):
 
     def test_session_unicode(self):
-        """
-        Makes sure printing a session doesn't crash.
-        """
+        """Makes sure printing a session doesn't crash."""
         with captured_output() as (out, err):
             sessions = AudioUtilities.GetAllSessions()
             print("sessions: %s" % sessions)
@@ -39,9 +37,7 @@ class TestCore(unittest.TestCase):
                 print("session.Process: %s" % session.Process)
 
     def test_device_unicode(self):
-        """
-        Makes sure printing a device doesn't crash.
-        """
+        """Makes sure printing a device doesn't crash."""
         with captured_output() as (out, err):
             devices = AudioUtilities.GetAllDevices()
             print("devices: %s" % devices)
@@ -49,20 +45,23 @@ class TestCore(unittest.TestCase):
                 print("device: %s" % device)
 
     def test_device_failed_properties(self):
-        """
-        Makes sure printing a device doesn't crash.
-        """
-
+        """Test that failed properties do not crash the script"""
+        dev = mock.Mock()
+        dev.GetId = mock.Mock(return_value="id")
+        dev.GetState = mock.Mock(return_value=AudioDeviceState.Active)
+        store = mock.Mock()
+        store.GetCount = mock.Mock(return_value=1)
+        store.GetAt = mock.Mock(return_value="pk")
+        store.GetValue = mock.Mock(
+            side_effect=_ctypes.COMError(None, None, None)
+        )
+        dev.OpenPropertyStore = mock.Mock(return_value=store)
         with captured_output() as (out, err):
-            dev = mock.Mock()
-            dev.GetId = mock.Mock(return_value="id")
-            dev.GetState = mock.Mock(return_value=AudioDeviceState.Active)
-            store = mock.Mock()
-            store.GetCount = mock.Mock(return_value=3)
-            store.GetAt = mock.Mock(return_value="pk")
-            store.GetValue = mock.Mock(side_effect=_ctypes.COMError(None, None, None))
-            dev.OpenPropertyStore = mock.Mock(return_value=store)
-            audev = AudioUtilities.CreateDevice(dev)
+            AudioUtilities.CreateDevice(dev)
+        self.assertTrue(
+            "UserWarning: COMError attempting to get property 0 from device"
+            in err.getvalue()
+        )
 
     def test_getallsessions_reliability(self):
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,10 +2,12 @@
 Verifies core features run as expected.
 """
 from __future__ import print_function
+import _ctypes
 import sys
 import unittest
+from unittest import mock
 from contextlib import contextmanager
-from pycaw.pycaw import AudioUtilities
+from pycaw.pycaw import AudioDeviceState, AudioUtilities
 try:
     from StringIO import StringIO
 except ImportError:
@@ -45,6 +47,22 @@ class TestCore(unittest.TestCase):
             print("devices: %s" % devices)
             for device in devices:
                 print("device: %s" % device)
+
+    def test_device_failed_properties(self):
+        """
+        Makes sure printing a device doesn't crash.
+        """
+
+        with captured_output() as (out, err):
+            dev = mock.Mock()
+            dev.GetId = mock.Mock(return_value="id")
+            dev.GetState = mock.Mock(return_value=AudioDeviceState.Active)
+            store = mock.Mock()
+            store.GetCount = mock.Mock(return_value=3)
+            store.GetAt = mock.Mock(return_value="pk")
+            store.GetValue = mock.Mock(side_effect=_ctypes.COMError(None, None, None))
+            dev.OpenPropertyStore = mock.Mock(return_value=store)
+            audev = AudioUtilities.CreateDevice(dev)
 
     def test_getallsessions_reliability(self):
         """


### PR DESCRIPTION
Fixes issues #15 by catching the specific exception and adding a warning. Test also added which passes for me.