### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 def read(fname):
@@ -18,5 +18,5 @@ setup(name='pycaw',
       long_description_content_type='text/markdown',
       author='Andre Miras',
       url='https://github.com/AndreMiras/pycaw',
-      packages=['pycaw'],
+      packages=find_packages(),
       install_requires=install_requires)


### PR DESCRIPTION
Let the setup tools find the packages instead of listing them explicit.

Because the `api` package is not listed in the `packages` in the setup.py, the package is not getting installed when installing the dev version via pip.
This fix lets setuptools find the packages automatically which should avoid having to update the setup.py manually.

