### PR TITLE
fixes mem leak from PROPVARIANT

### DIFF
--- a/pycaw/api/mmdeviceapi/depend/structures.py
+++ b/pycaw/api/mmdeviceapi/depend/structures.py
@@ -1,9 +1,8 @@
-from ctypes import Structure, Union
+from ctypes import Structure, Union, byref, windll
 from ctypes.wintypes import DWORD, LONG, LPWSTR, ULARGE_INTEGER, VARIANT_BOOL, WORD
 
 from comtypes import GUID
 from comtypes.automation import VARTYPE, VT_BOOL, VT_CLSID, VT_LPWSTR, VT_UI4
-
 
 class PROPVARIANT_UNION(Union):
     _fields_ = [
@@ -39,6 +38,9 @@ class PROPVARIANT(Structure):
             return
         else:
             return "%s:?" % (vt)
+    
+    def clear(self):
+        windll.ole32.PropVariantClear(byref(self))
 
 
 class PROPERTYKEY(Structure):

--- a/pycaw/api/mmdeviceapi/depend/structures.py
+++ b/pycaw/api/mmdeviceapi/depend/structures.py
@@ -4,6 +4,7 @@ from ctypes.wintypes import DWORD, LONG, LPWSTR, ULARGE_INTEGER, VARIANT_BOOL, W
 from comtypes import GUID
 from comtypes.automation import VARTYPE, VT_BOOL, VT_CLSID, VT_LPWSTR, VT_UI4
 
+
 class PROPVARIANT_UNION(Union):
     _fields_ = [
         ("lVal", LONG),
@@ -38,7 +39,7 @@ class PROPVARIANT(Structure):
             return
         else:
             return "%s:?" % (vt)
-    
+
     def clear(self):
         windll.ole32.PropVariantClear(byref(self))
 

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -246,6 +246,7 @@ class AudioUtilities:
                     continue
                 # TODO
                 # PropVariantClear(byref(value))
+                value.clear()
                 name = str(pk)
                 properties[name] = v
         audioState = AudioDeviceState(state)

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -244,8 +244,6 @@ class AudioUtilities:
                         "from device %r: %r" % (j, dev, exc)
                     )
                     continue
-                # TODO
-                # PropVariantClear(byref(value))
                 value.clear()
                 name = str(pk)
                 properties[name] = v


### PR DESCRIPTION
This is pretty noticeable memory leak from `CreateDevice` that gets data from store `PROPVARIANT` aka the `value = store.GetValue(pk)`. This PR will use ole32 PropVariantClear to clear `value` to solve the memory leak issue.