### PR TITLE
fix double free due to using cast rather than QueryInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,12 @@ choco install visualcpp-build-tools
 ## Usage
 
 ```Python
-from ctypes import cast, POINTER
 from comtypes import CLSCTX_ALL
 from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
 devices = AudioUtilities.GetSpeakers()
 interface = devices.Activate(
     IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
-volume = cast(interface, POINTER(IAudioEndpointVolume))
+volume = interface.QueryInterface(IAudioEndpointVolume)
 volume.GetMute()
 volume.GetMasterVolumeLevel()
 volume.GetVolumeRange()

--- a/examples/audio_endpoint_volume_example.py
+++ b/examples/audio_endpoint_volume_example.py
@@ -1,8 +1,6 @@
 """
 Get and set access to master volume example.
 """
-from ctypes import POINTER, cast
-
 from comtypes import CLSCTX_ALL
 
 from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
@@ -11,7 +9,7 @@ from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
 def main():
     devices = AudioUtilities.GetSpeakers()
     interface = devices.Activate(IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
-    volume = cast(interface, POINTER(IAudioEndpointVolume))
+    volume = interface.QueryInterface(IAudioEndpointVolume)
     print("volume.GetMute(): %s" % volume.GetMute())
     print("volume.GetMasterVolumeLevel(): %s" % volume.GetMasterVolumeLevel())
     print("volume.GetVolumeRange(): (%s, %s, %s)" % volume.GetVolumeRange())

--- a/examples/volume_callback_example.py
+++ b/examples/volume_callback_example.py
@@ -2,8 +2,6 @@
 IAudioEndpointVolumeCallback.OnNotify() example.
 The OnNotify() callback method gets called on volume change.
 """
-from ctypes import POINTER, cast
-
 from comtypes import CLSCTX_ALL, COMObject
 
 from pycaw.pycaw import (
@@ -23,7 +21,7 @@ class AudioEndpointVolumeCallback(COMObject):
 def main():
     devices = AudioUtilities.GetSpeakers()
     interface = devices.Activate(IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
-    volume = cast(interface, POINTER(IAudioEndpointVolume))
+    volume = interface.QueryInterface(IAudioEndpointVolume)
     callback = AudioEndpointVolumeCallback()
     volume.RegisterControlChangeNotify(callback)
     for i in range(3):

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -1,5 +1,4 @@
 import warnings
-from ctypes import POINTER, cast
 
 import comtypes
 import psutil
@@ -49,7 +48,7 @@ class AudioDevice:
             iface = self._dev.Activate(
                 IAudioEndpointVolume._iid_, comtypes.CLSCTX_ALL, None
             )
-            self._volume = cast(iface, POINTER(IAudioEndpointVolume))
+            self._volume = iface.QueryInterface(IAudioEndpointVolume)
         return self._volume
 
 


### PR DESCRIPTION
Fixes (hopefully):
* https://github.com/AndreMiras/pycaw/issues/19
* https://github.com/ho0ber/havomi/issues/13
* https://github.com/AndreMiras/pycaw/issues/52

See https://github.com/AndreMiras/pycaw/issues/19#issuecomment-1528995706 for an explanation + repro of the bug