### PR TITLE
Add Adding IChannelAudioVolume interface

### DIFF
--- a/examples/channel_audio_volume_example.py
+++ b/examples/channel_audio_volume_example.py
@@ -1,0 +1,22 @@
+"""
+Adjusting volume of left channel using IChannelAudioVolume.
+"""
+
+from pycaw.pycaw import AudioUtilities
+
+
+def main():
+    sessions = AudioUtilities.GetAllSessions()
+    for session in sessions:
+        volume = session.channelAudioVolume()
+        print(f"Session {session}")
+        count = volume.GetChannelCount()
+        volumes = [volume.GetChannelVolume(i) for i in range(count)]
+        print(f"    volumes = {volumes}")
+        if count == 2:
+            volume.SetChannelVolume(0, 0.1, None)
+            print("    Set the volume of left channel to 0.5!")
+
+
+if __name__ == "__main__":
+    main()

--- a/pycaw/api/audioclient/__init__.py
+++ b/pycaw/api/audioclient/__init__.py
@@ -137,3 +137,27 @@ class IAudioClient(IUnknown):
             (["out"], POINTER(POINTER(IUnknown)), "ppv"),
         ),
     )
+
+
+class IChannelAudioVolume(IUnknown):
+    _iid_ = GUID("{1c158861-b533-4b30-b1cf-e853e51c59b8}")
+    _methods_ = (
+        COMMETHOD(
+            [], HRESULT, "GetChannelCount", (["out"], POINTER(UINT32), "pnChannelCount")
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetChannelVolume",
+            (["in"], UINT32, "dwIndex"),
+            (["in"], c_float, "fLevel"),
+            (["in"], POINTER(GUID), "EventContext"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetChannelVolume",
+            (["in"], UINT32, "dwIndex"),
+            (["out"], POINTER(c_float), "pfLevel"),
+        ),
+    )

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -4,7 +4,7 @@ import comtypes
 import psutil
 from _ctypes import COMError
 
-from pycaw.api.audioclient import ISimpleAudioVolume
+from pycaw.api.audioclient import IChannelAudioVolume, ISimpleAudioVolume
 from pycaw.api.audiopolicy import IAudioSessionControl2, IAudioSessionManager2
 from pycaw.api.endpointvolume import IAudioEndpointVolume
 from pycaw.api.mmdeviceapi import IMMDeviceEnumerator, IMMEndpoint
@@ -61,6 +61,7 @@ class AudioSession:
         self._ctl = audio_session_control2
         self._process = None
         self._volume = None
+        self._channelVolume = None
         self._callback = None
 
     def __str__(self):
@@ -144,6 +145,11 @@ class AudioSession:
         if self._volume is None:
             self._volume = self._ctl.QueryInterface(ISimpleAudioVolume)
         return self._volume
+
+    def channelAudioVolume(self):
+        if self._channelVolume is None:
+            self._channelVolume = self._ctl.QueryInterface(IChannelAudioVolume)
+        return self._channelVolume
 
     def register_notification(self, callback):
         if self._callback is None:


### PR DESCRIPTION
Hello! I am one of developers of [NVDA](https://github.com/nvaccess/nvda) - a screenreader for the blind. We would like to make use of pycaw for soundSplit feature: that involves setting volume for left and right channel separately. However I found that `IChannelAudioVolume` interface from core audio API is not present, so I would like to add it.

For more context see nvaccess/nvda#16071.

Thanks!