### PR TITLE
:arrow_up: Bump Python versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        python: ['3.7', '3.8', '3.9', '3.10']
+        python: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [unreleased]
+    - fix double free due to using cast rather than QueryInterface, refs #74 (@mrob95)
+    - add: example for IMMNotificationClient, refs #77 (@Invisi)
+    - IChannelAudioVolume support, refs #87 (@mltony)
+
 ## [20230407]
     - Fixes memory leak from PROPVARIANT, refs #72 (@KillerBOSS2019)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint-check,py{37,38,39,310}
+envlist = lint-check,py{38,39,310,311,312}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
Drops Python 3.7 (EOL), add 3.11 and 3.12