### PR TITLE
Functionality to list audio devices and change default audio device (+ minimal example)

### DIFF
--- a/examples/audio_endpoint_volume_example.py
+++ b/examples/audio_endpoint_volume_example.py
@@ -8,9 +8,9 @@ from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
 
 
 def main():
-    devices = AudioUtilities.GetSpeakers()
-    interface = devices.Activate(IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
-    volume = interface.QueryInterface(IAudioEndpointVolume)
+    device = AudioUtilities.GetSpeakers()
+    print("Device found: %s" % device.FriendlyName)
+    volume = device.EndpointVolume
     print("volume.GetMute(): %s" % volume.GetMute())
     print("volume.GetMasterVolumeLevel(): %s" % volume.GetMasterVolumeLevel())
     print("volume.GetVolumeRange(): (%s, %s, %s)" % volume.GetVolumeRange())

--- a/examples/audio_endpoint_volume_example.py
+++ b/examples/audio_endpoint_volume_example.py
@@ -2,9 +2,7 @@
 Get and set access to master volume example.
 """
 
-from comtypes import CLSCTX_ALL
-
-from pycaw.pycaw import AudioUtilities, IAudioEndpointVolume
+from pycaw.pycaw import AudioUtilities
 
 
 def main():

--- a/examples/list_and_switch_devices_example.py
+++ b/examples/list_and_switch_devices_example.py
@@ -8,7 +8,7 @@ from pycaw.utils import AudioDevice
 import warnings
 
 
-def list_active_output_devices():
+def get_active_output_devices():
     with warnings.catch_warnings():  # suppress COMError warnings
         warnings.simplefilter("ignore", UserWarning)
         return AudioUtilities.GetAllDevices(data_flow=EDataFlow.eRender.value,
@@ -26,7 +26,7 @@ def set_default_device(device: AudioDevice):
 if __name__ == "__main__":
     # List devices
     print("List of available output devices (* = default): ")
-    active_output_devices = list_active_output_devices()
+    active_output_devices = get_active_output_devices()
     default_device = get_default_device()
     other_device = None
     for device in active_output_devices:

--- a/examples/list_and_switch_devices_example.py
+++ b/examples/list_and_switch_devices_example.py
@@ -11,7 +11,8 @@ import warnings
 def list_active_output_devices():
     with warnings.catch_warnings():  # suppress COMError warnings
         warnings.simplefilter("ignore", UserWarning)
-        return AudioUtilities.GetAllDevices(data_flow=EDataFlow.eRender.value, device_state=DEVICE_STATE.ACTIVE.value)
+        return AudioUtilities.GetAllDevices(data_flow=EDataFlow.eRender.value,
+                                            device_state=DEVICE_STATE.ACTIVE.value)
 
 
 def get_default_device():

--- a/examples/list_and_switch_devices_example.py
+++ b/examples/list_and_switch_devices_example.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
 
         # List devices again
         print("Updated list of available output devices (* = default): ")
-        active_output_devices = list_active_output_devices()
+        active_output_devices = get_active_output_devices()
         default_device = get_default_device()
         for device in active_output_devices:
             if device.id == default_device.id:

--- a/examples/list_and_switch_devices_example.py
+++ b/examples/list_and_switch_devices_example.py
@@ -1,0 +1,51 @@
+"""
+Example to list and switch devices.
+"""
+
+from pycaw.constants import EDataFlow, DEVICE_STATE
+from pycaw.pycaw import AudioUtilities
+from pycaw.utils import AudioDevice
+import warnings
+
+
+def list_active_output_devices():
+    with warnings.catch_warnings():  # suppress COMError warnings
+        warnings.simplefilter("ignore", UserWarning)
+        return AudioUtilities.GetAllDevices(data_flow=EDataFlow.eRender.value, device_state=DEVICE_STATE.ACTIVE.value)
+
+
+def get_default_device():
+    return AudioUtilities.GetSpeakers()
+
+
+def set_default_device(device: AudioDevice):
+    AudioUtilities.SetDefaultDevice(device.id)
+
+
+if __name__ == "__main__":
+    # List devices
+    print("List of available output devices (* = default): ")
+    active_output_devices = list_active_output_devices()
+    default_device = get_default_device()
+    other_device = None
+    for device in active_output_devices:
+        if device.id == default_device.id:
+            print(f" * {device.FriendlyName}")
+        else:
+            print(f"   {device.FriendlyName}")
+            other_device = device
+
+    if other_device is not None:
+        # Change default to other device
+        print(f"Changing default device to {other_device.FriendlyName}...")
+        set_default_device(other_device)
+
+        # List devices again
+        print("Updated list of available output devices (* = default): ")
+        active_output_devices = list_active_output_devices()
+        default_device = get_default_device()
+        for device in active_output_devices:
+            if device.id == default_device.id:
+                print(f"* {device.FriendlyName}")
+            else:
+                print(f"  {device.FriendlyName}")

--- a/examples/volume_callback_example.py
+++ b/examples/volume_callback_example.py
@@ -20,9 +20,8 @@ class AudioEndpointVolumeCallback(COMObject):
 
 
 def main():
-    devices = AudioUtilities.GetSpeakers()
-    interface = devices.Activate(IAudioEndpointVolume._iid_, CLSCTX_ALL, None)
-    volume = interface.QueryInterface(IAudioEndpointVolume)
+    device = AudioUtilities.GetSpeakers()
+    volume = device.EndpointVolume
     callback = AudioEndpointVolumeCallback()
     volume.RegisterControlChangeNotify(callback)
     for _ in range(3):

--- a/examples/volume_callback_example.py
+++ b/examples/volume_callback_example.py
@@ -3,13 +3,8 @@ IAudioEndpointVolumeCallback.OnNotify() example.
 The OnNotify() callback method gets called on volume change.
 """
 
-from comtypes import CLSCTX_ALL, COMObject
-
-from pycaw.pycaw import (
-    AudioUtilities,
-    IAudioEndpointVolume,
-    IAudioEndpointVolumeCallback,
-)
+from comtypes import COMObject
+from pycaw.pycaw import AudioUtilities, IAudioEndpointVolumeCallback
 
 
 class AudioEndpointVolumeCallback(COMObject):

--- a/pycaw/api/policyconfig/__init__.py
+++ b/pycaw/api/policyconfig/__init__.py
@@ -1,0 +1,112 @@
+from ctypes import HRESULT, POINTER, c_longlong, Structure, c_int, c_bool
+from ctypes.wintypes import BOOL, DWORD, LPCWSTR
+from comtypes import COMMETHOD, GUID, IUnknown
+
+from pycaw.api.audioclient import WAVEFORMATEX
+from pycaw.api.mmdeviceapi import PROPERTYKEY
+from pycaw.api.mmdeviceapi.depend import PROPVARIANT
+
+REFERENCE_TIME = c_longlong
+
+
+class DeviceSharedMode(Structure):
+    _fields_ = [
+        ("Mode", c_int),
+        ("bIsEventDriven", c_bool),
+    ]
+
+
+class IPolicyConfig(IUnknown):
+    _case_insensitive_ = True
+    _iid_ = GUID("{f8679f50-850a-41cf-9c72-430f290290c8}")
+    _methods_ = (
+        COMMETHOD(
+            [], 
+            HRESULT, 
+            "GetMixFormat",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["out"], POINTER(POINTER(WAVEFORMATEX)), "ppDeviceFormat"),
+        ),
+        COMMETHOD(
+            [], 
+            HRESULT, 
+            "GetDeviceFormat", 
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], BOOL, "bDefault"), 
+            (["out"], POINTER(POINTER(WAVEFORMATEX)), "ppDeviceFormat"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "ResetDeviceFormat",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetDeviceFormat",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], POINTER(WAVEFORMATEX), "pEndpointFormat"),
+            (["in"], POINTER(WAVEFORMATEX), "pMixFormat"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetProcessingPeriod",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], BOOL, "bDefault"),
+            (["out"], POINTER(REFERENCE_TIME), "hnsDefaultDevicePeriod"),
+            (["out"], POINTER(REFERENCE_TIME), "hnsMinimumDevicePeriod"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetProcessingPeriod",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], POINTER(REFERENCE_TIME), "hnsDevicePeriod"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetShareMode",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["out"], POINTER(DeviceSharedMode), "pMode"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetShareMode",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], POINTER(DeviceSharedMode), "pMode"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "GetPropertyValue",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], POINTER(PROPERTYKEY), "pKey"),
+            (["out"], POINTER(PROPVARIANT), "pValue"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetPropertyValue",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], POINTER(PROPERTYKEY), "pKey"),
+            (["in"], POINTER(PROPVARIANT), "pValue"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetDefaultEndpoint",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], DWORD, "role"),
+        ),
+        COMMETHOD(
+            [],
+            HRESULT,
+            "SetEndpointVisibility",
+            (["in"], LPCWSTR, "pwstrDeviceId"),
+            (["in"], BOOL, "bVisible"),
+        ),
+    )

--- a/pycaw/api/policyconfig/__init__.py
+++ b/pycaw/api/policyconfig/__init__.py
@@ -1,84 +1,23 @@
-from ctypes import HRESULT, POINTER, c_longlong, Structure, c_int, c_bool
+from ctypes import HRESULT, POINTER
 from ctypes.wintypes import BOOL, DWORD, LPCWSTR
 from comtypes import COMMETHOD, GUID, IUnknown
 
-from pycaw.api.audioclient import WAVEFORMATEX
 from pycaw.api.mmdeviceapi import PROPERTYKEY
 from pycaw.api.mmdeviceapi.depend import PROPVARIANT
-
-REFERENCE_TIME = c_longlong
-
-
-class DeviceSharedMode(Structure):
-    _fields_ = [
-        ("Mode", c_int),
-        ("bIsEventDriven", c_bool),
-    ]
 
 
 class IPolicyConfig(IUnknown):
     _case_insensitive_ = True
     _iid_ = GUID("{f8679f50-850a-41cf-9c72-430f290290c8}")
     _methods_ = (
-        COMMETHOD(
-            [], 
-            HRESULT, 
-            "GetMixFormat",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["out"], POINTER(POINTER(WAVEFORMATEX)), "ppDeviceFormat"),
-        ),
-        COMMETHOD(
-            [], 
-            HRESULT, 
-            "GetDeviceFormat", 
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["in"], BOOL, "bDefault"), 
-            (["out"], POINTER(POINTER(WAVEFORMATEX)), "ppDeviceFormat"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "ResetDeviceFormat",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "SetDeviceFormat",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["in"], POINTER(WAVEFORMATEX), "pEndpointFormat"),
-            (["in"], POINTER(WAVEFORMATEX), "pMixFormat"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "GetProcessingPeriod",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["in"], BOOL, "bDefault"),
-            (["out"], POINTER(REFERENCE_TIME), "hnsDefaultDevicePeriod"),
-            (["out"], POINTER(REFERENCE_TIME), "hnsMinimumDevicePeriod"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "SetProcessingPeriod",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["in"], POINTER(REFERENCE_TIME), "hnsDevicePeriod"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "GetShareMode",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["out"], POINTER(DeviceSharedMode), "pMode"),
-        ),
-        COMMETHOD(
-            [],
-            HRESULT,
-            "SetShareMode",
-            (["in"], LPCWSTR, "pwstrDeviceId"),
-            (["in"], POINTER(DeviceSharedMode), "pMode"),
-        ),
+        COMMETHOD([], HRESULT, "Unused1"),
+        COMMETHOD([], HRESULT, "Unused2"),
+        COMMETHOD([], HRESULT, "Unused3"),
+        COMMETHOD([], HRESULT, "Unused4"),
+        COMMETHOD([], HRESULT, "Unused5"),
+        COMMETHOD([], HRESULT, "Unused6"),
+        COMMETHOD([], HRESULT, "Unused7"),
+        COMMETHOD([], HRESULT, "Unused8"),
         COMMETHOD(
             [],
             HRESULT,

--- a/pycaw/constants.py
+++ b/pycaw/constants.py
@@ -5,6 +5,7 @@ from comtypes import GUID
 IID_Empty = GUID("{00000000-0000-0000-0000-000000000000}")
 
 CLSID_MMDeviceEnumerator = GUID("{BCDE0395-E52F-467C-8E3D-C4579291692E}")
+CLSID_CPolicyConfigClient = GUID('{870af99c-171d-4f9e-af0d-e63df40c2bc9}')
 
 
 class ERole(Enum):

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -8,6 +8,7 @@ from pycaw.api.audioclient import IChannelAudioVolume, ISimpleAudioVolume
 from pycaw.api.audiopolicy import IAudioSessionControl2, IAudioSessionManager2
 from pycaw.api.endpointvolume import IAudioEndpointVolume
 from pycaw.api.mmdeviceapi import IMMDeviceEnumerator, IMMEndpoint
+from pycaw.api.policyconfig import IPolicyConfig
 from pycaw.constants import (
     DEVICE_STATE,
     STGM,
@@ -16,6 +17,7 @@ from pycaw.constants import (
     EDataFlow,
     ERole,
     IID_Empty,
+    CLSID_CPolicyConfigClient,
 )
 
 
@@ -177,7 +179,7 @@ class AudioUtilities:
         speakers = deviceEnumerator.GetDefaultAudioEndpoint(
             EDataFlow.eRender.value, ERole.eMultimedia.value
         )
-        return speakers
+        return AudioUtilities.CreateDevice(speakers)
 
     @staticmethod
     def GetMicrophone():
@@ -256,7 +258,7 @@ class AudioUtilities:
         return AudioDevice(id, audioState, properties, dev)
 
     @staticmethod
-    def GetAllDevices():
+    def GetAllDevices(data_flow=EDataFlow.eAll.value, device_state=DEVICE_STATE.MASK_ALL.value):
         devices = []
         deviceEnumerator = comtypes.CoCreateInstance(
             CLSID_MMDeviceEnumerator, IMMDeviceEnumerator, comtypes.CLSCTX_INPROC_SERVER
@@ -265,7 +267,7 @@ class AudioUtilities:
             return devices
 
         collection = deviceEnumerator.EnumAudioEndpoints(
-            EDataFlow.eAll.value, DEVICE_STATE.MASK_ALL.value
+            data_flow, device_state
         )
         if collection is None:
             return devices
@@ -303,3 +305,15 @@ class AudioUtilities:
             return value
         else:
             return DataFlow[value]
+
+    @staticmethod
+    def SetDefaultDevice(devId, roles=None):
+        if roles is None:
+            roles = [ERole.eConsole]
+        policy_config = comtypes.CoCreateInstance(
+            CLSID_CPolicyConfigClient, IPolicyConfig, comtypes.CLSCTX_ALL
+        )
+        for role in roles:
+            hr = policy_config.SetDefaultEndpoint(devId, role.value)
+            if hr != 0:
+                raise OSError(f"SetDefaultEndpoint failed for role {role} with HRESULT {hr:#x}")

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -258,7 +258,8 @@ class AudioUtilities:
         return AudioDevice(id, audioState, properties, dev)
 
     @staticmethod
-    def GetAllDevices(data_flow=EDataFlow.eAll.value, device_state=DEVICE_STATE.MASK_ALL.value):
+    def GetAllDevices(data_flow=EDataFlow.eAll.value,
+                      device_state=DEVICE_STATE.MASK_ALL.value):
         devices = []
         deviceEnumerator = comtypes.CoCreateInstance(
             CLSID_MMDeviceEnumerator, IMMDeviceEnumerator, comtypes.CLSCTX_INPROC_SERVER
@@ -316,4 +317,5 @@ class AudioUtilities:
         for role in roles:
             hr = policy_config.SetDefaultEndpoint(devId, role.value)
             if hr != 0:
-                raise OSError(f"SetDefaultEndpoint failed for role {role} with HRESULT {hr:#x}")
+                raise OSError(f"SetDefaultEndpoint failed for role {role} "
+                              f"with HRESULT {hr:#x}")


### PR DESCRIPTION
Fixes #49 (Get list or Switch audio devices)

Changes:
- added policyconfig to switch audiodevices + added example
- updated GetAllDevices() to allow arguments data_flow and device_state to filter the output (e.g., only show available devices)
- updated GetSpeakers() to return of type AudioDevice (for better consistency) + updated corresponding examples