### PR TITLE
Add AudioDevice.volume_percent property (percentage based master volume)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## [Unreleased]
+    - Add AudioDevice.volume_percent property for percentage based master volume, refs #13 (@ahmetberber)
     - Add SetDefaultDevice functionality to switch default audio devices, refs #49, #103 (@bdieudonne)
     - Add policyconfig API module (IPolicyConfig) for device management, refs #103 (@bdieudonne)
     - Add GetAllDevices() filters for data_flow and device_state, refs #103 (@bdieudonne)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ print(f"- Muted: {bool(volume.GetMute())}")
 print(f"- Volume level: {volume.GetMasterVolumeLevel()} dB")
 print(f"- Volume range: {volume.GetVolumeRange()[0]} dB - {volume.GetVolumeRange()[1]} dB")
 volume.SetMasterVolumeLevel(-20.0, None)
+# or work with the 0-100 scale the Windows volume mixer uses:
+print(f"- Volume: {device.volume_percent:.0f}%")
+device.volume_percent = 50
 ```
 
 See more in the [examples](examples/) directory or visit the [documentation](https://andremiras.github.io/pycaw/).

--- a/examples/master_volume_percent_example.py
+++ b/examples/master_volume_percent_example.py
@@ -1,0 +1,25 @@
+"""
+Get and set the master volume by percentage example.
+
+`volume_percent` uses the same 0-100 scale as the Windows volume mixer,
+unlike `SetMasterVolumeLevel()` which expects decibels.
+"""
+
+from pycaw.pycaw import AudioUtilities
+
+
+def main():
+    device = AudioUtilities.GetSpeakers()
+    print("Device found: %s" % device.FriendlyName)
+    original = device.volume_percent
+    print("volume_percent: %.0f%%" % original)
+    print("setting volume to 50%")
+    device.volume_percent = 50
+    print("volume_percent: %.0f%%" % device.volume_percent)
+    print("restoring original volume")
+    device.volume_percent = original
+    print("volume_percent: %.0f%%" % device.volume_percent)
+
+
+if __name__ == "__main__":
+    main()

--- a/pycaw/utils.py
+++ b/pycaw/utils.py
@@ -63,6 +63,24 @@ class AudioDevice:
         return self._volume
 
     @property
+    def volume_percent(self):
+        """
+        Master volume of this device as a percentage (0.0-100.0), the same
+        scale the Windows volume mixer shows.
+
+        Convenience wrapper around `GetMasterVolumeLevelScalar()` /
+        `SetMasterVolumeLevelScalar()`, so users don't reach for the decibel
+        based `SetMasterVolumeLevel()` by mistake. The setter clamps the
+        value to the 0-100 range.
+        """
+        return self.EndpointVolume.GetMasterVolumeLevelScalar() * 100
+
+    @volume_percent.setter
+    def volume_percent(self, percent):
+        percent = max(0.0, min(100.0, percent))
+        self.EndpointVolume.SetMasterVolumeLevelScalar(percent / 100, None)
+
+    @property
     def AudioSessionManager(self):
         if self._audio_session_manager is None:
             # win7+ only

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,6 +11,7 @@ from unittest import mock
 import _ctypes
 
 from pycaw.pycaw import AudioDeviceState, AudioUtilities
+from pycaw.utils import AudioDevice
 
 
 @contextmanager
@@ -66,3 +67,21 @@ class TestCore:
         for _ in range(100):
             sessions = AudioUtilities.GetAllSessions()
             assert len(sessions) > 0
+
+    def test_volume_percent(self):
+        """
+        volume_percent maps to the endpoint volume scalar (0-100 <-> 0.0-1.0)
+        and the setter clamps out of range values, refs:
+        https://github.com/AndreMiras/pycaw/issues/13
+        """
+        device = AudioDevice("id", AudioDeviceState.Active, {}, mock.Mock())
+        endpoint = mock.Mock()
+        endpoint.GetMasterVolumeLevelScalar = mock.Mock(return_value=0.25)
+        device._volume = endpoint
+        assert device.volume_percent == 25.0
+        device.volume_percent = 50
+        endpoint.SetMasterVolumeLevelScalar.assert_called_with(0.5, None)
+        device.volume_percent = 150
+        endpoint.SetMasterVolumeLevelScalar.assert_called_with(1.0, None)
+        device.volume_percent = -10
+        endpoint.SetMasterVolumeLevelScalar.assert_called_with(0.0, None)


### PR DESCRIPTION
Closes #13, where percentage based volume control was requested and a PR was invited — this adds it as a small convenience on `AudioDevice`.

## What

- `AudioDevice.volume_percent` property (getter/setter) exposing the master volume on the **0–100 scale the Windows volume mixer uses**, wrapping `GetMasterVolumeLevelScalar()` / `SetMasterVolumeLevelScalar()`. The setter clamps out-of-range values.
- `examples/master_volume_percent_example.py` — runnable example (reads, sets to 50 %, restores).
- Unit test covering the scalar mapping and clamping (mock based, no audio device needed).
- README usage snippet + CHANGELOG entry.

## Why

The dB based `SetMasterVolumeLevel()` vs. scalar confusion is a recurring stumbling block for pycaw users (see #13); a discoverable `volume_percent` next to `EndpointVolume` makes the common case obvious without changing any existing API.

## Verification

Tested on Windows 11, Python 3.12.10, real hardware (TOPPING USB DAC):

```
Device found: Speakers (TOPPING USB DAC)
volume_percent: 60%
setting volume to 50%
volume_percent: 50%
restoring original volume
volume_percent: 60%
```

`tests/test_core.py` — 5 passed (including the new `test_volume_percent`). `black` / `isort` / `flake8` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)